### PR TITLE
fix combateventcapture

### DIFF
--- a/DeathRecap.csproj
+++ b/DeathRecap.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <PlatformTarget>x64</PlatformTarget>
-        <TargetFramework>net7.0-windows</TargetFramework>
+        <TargetFramework>net8.0-windows</TargetFramework>
         <LangVersion>latest</LangVersion>
         <Platforms>x64</Platforms>
         <Configurations>Debug;Release</Configurations>

--- a/Events/CombatEventCapture.cs
+++ b/Events/CombatEventCapture.cs
@@ -216,6 +216,21 @@ public class CombatEventCapture : IDisposable {
                     combatEvents.AddEntry(entityId, new CombatEvent.DoT { Snapshot = p.Snapshot(), Amount = amount });
                     break;
                 case ActorControlCategory.HoT:
+                    if (a3 != 0)
+                    {
+                        var source_name = Service.ObjectTable.SearchById(entityId)!.Name.TextValue;
+                        var status = Service.DataManager.GetExcelSheet<Status>()!.GetRow(a3);
+                        combatEvents.AddEntry(entityId, new CombatEvent.Healed
+                        {
+                            Snapshot = p.Snapshot(),
+                            Source = source_name,
+                            Amount = amount,
+                            Action = status?.Name.RawString?.Demangle() ?? "",
+                            Icon = (ushort?)(status?.Icon),
+                            Crit = source == 1
+                        });
+                        break;
+                    }
                     combatEvents.AddEntry(entityId, new CombatEvent.HoT { Snapshot = p.Snapshot(), Amount = amount });
                     break;
                 case ActorControlCategory.Death: {

--- a/packages.lock.json
+++ b/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "dependencies": {
-    "net7.0-windows7.0": {
+    "net8.0-windows7.0": {
       "DalamudPackager": {
         "type": "Direct",
         "requested": "[2.1.12, )",


### PR DESCRIPTION
Fixed the classification of recovery as a HoT event when it is triggered by Kardion or Nascent Glint.

a3 = statusId
source = iscrit

This is my first pull request so sorry if there are any problems.