### PR TITLE
Add ability to record job name as damage source in PvP

### DIFF
--- a/Configuration.cs
+++ b/Configuration.cs
@@ -24,6 +24,7 @@ public class Configuration : IPluginConfiguration {
         new() { Capture = false, NotificationStyle = NotificationStyle.Chat, OnlyInstances = true, DisableInPvp = true };
 
     public bool ShowTip { get; set; } = true;
+    public bool RecordJobsAsSourceInPvp { get; set; } = false;
     public int KeepCombatEventsForSeconds { get; set; } = 60;
     public int KeepDeathsForMinutes { get; set; } = 60;
     public XivChatType ChatType { get; set; } = XivChatType.SystemMessage;

--- a/UI/ConfigWindow.cs
+++ b/UI/ConfigWindow.cs
@@ -102,6 +102,14 @@ public class ConfigWindow : Window {
             conf.KeepDeathsForMinutes = keepDeathsFor;
             conf.Save();
         }
+        
+        
+        var bRecordJobsAsSourceInPvp = conf.RecordJobsAsSourceInPvp;
+        if (ImGui.Checkbox("Record job name as damage source in PvP", ref bRecordJobsAsSourceInPvp)) {
+            conf.RecordJobsAsSourceInPvp = bRecordJobsAsSourceInPvp;
+            conf.Save();
+        }
+        RecordJobsAsSourceInPvpTooltip();
     }
 
     private static void ChatMessageTypeTooltip() {
@@ -115,6 +123,12 @@ public class ConfigWindow : Window {
     private static void ChatTipTooltip() {
         if (ImGui.IsItemHovered()) {
             ImGui.SetTooltip("Prints the command in the chat to reopen the window the first time you close the Death Recap.");
+        }
+    }
+
+    private static void RecordJobsAsSourceInPvpTooltip() {
+        if (ImGui.IsItemHovered()) {
+            ImGui.SetTooltip("Uses the job name instead of player name as damage source in PvP.");
         }
     }
 


### PR DESCRIPTION
I didn't like how you could see player names when looking at the recap when playing PvP.

As it stands it's configured as an opt-in, but I don't think it'd be a bad idea to make it an opt-out.

Let me know if you want something or everything changed, I don't really know C# so I may have botched any number of things :)