### PR TITLE
Fix ImGui assertion

### DIFF
--- a/UI/DeathRecapWindow.cs
+++ b/UI/DeathRecapWindow.cs
@@ -188,7 +188,7 @@ public class DeathRecapWindow : Window {
         ImGui.TextUnformatted("Player");
         ImGui.SameLine();
         ImGui.SetNextItemWidth(200 * ImGuiHelpers.GlobalScale);
-        if (ImGui.BeginCombo("", selectedPlayerName)) {
+        if (ImGui.BeginCombo("##playerSelection", selectedPlayerName)) {
             var processed = new HashSet<ulong>();
 
             if (Service.PartyList.Length > 0) {


### PR DESCRIPTION
BeginCombo with an empty label causes an assertion, "Cannot have an empty ID at the root of a window. If you need an empty label, use ## and read the FAQ about how the ID Stack works!"

Went with adding a `##playerSelection` label to keep the empty label but a non-empty ID.