### PR TITLE
A few fixes and additions, mostly PvP-related.

### DIFF
--- a/Events/CombatEvent.cs
+++ b/Events/CombatEvent.cs
@@ -49,7 +49,7 @@ public record CombatEvent {
         public required ActionType DisplayType { get; init; }
         public bool Parried { get; init; }
         public bool Blocked { get; init; }
-        public required ushort? Icon { get; init; }
+        public required uint? Icon { get; init; }
     }
 
     public record Healed : CombatEvent {
@@ -58,5 +58,13 @@ public record CombatEvent {
         public required string Action { get; init; }
         public bool Crit { get; init; }
         public required uint? Icon { get; init; }
+    }
+
+    public record MedKit : CombatEvent {
+        public required uint Amount { get; init; }
+    }
+
+    public record FallDamage : CombatEvent {
+        public required uint Amount { get; init; }
     }
 }

--- a/Game/ActorControlCategory.cs
+++ b/Game/ActorControlCategory.cs
@@ -8,10 +8,12 @@ public enum ActorControlCategory : uint {
     UpdateEffect = 0x16,
     TargetIcon = 0x22,
     Tether = 0x23,
+    FallDamage = 0x2D,
     Targetable = 0x36,
     DirectorUpdate = 0x6D,
     SetTargetSign = 0x1F6,
     LimitBreak = 0x1F9,
+    MedKit = 0x5DC, //floor pots in Crystalline Conflict
     HoT = 0x604,
     DoT = 0x605
 }


### PR DESCRIPTION
This update fixes a few scenarios which are mostly relevant to PvP.

**1.**  Adds two new types of combat events based on ActorControl categories:

- **Medkits**: The potions that spawn on the ground of Crystalline Conflict matches and heal you when you step over them. Unaware if the same ActorControl category is used elsewhere in the game.
- **Fall Damage**: Damage sustained from falling from a height. Applies to both PvE and PvP.

**2.** Adds the status name, icon and source for DoTs which are resolvable to a status effect. (e.g. Pressure Point)

**3.** Fixes the source for status-related HoTs. (e.g. Catharsis of Corundum)

**4.** Checks for reflected damage and heals (Lifesteal and Thorns-type effects e.g. the PvP versions of Chaotic Spring and Nebula respectively) and applies them to the caster (if tracked) instead of the target.

**5.** Changed stored icon Ids from ushort to uint. Some icons were not being rendered.